### PR TITLE
Don't capture inactive tabs

### DIFF
--- a/src/scripts/background.ts
+++ b/src/scripts/background.ts
@@ -13,7 +13,7 @@ chrome.runtime.onMessage.addListener((message, sender, res) => {
   if (sender.tab?.id === undefined) return;
   const tabId: number = sender.tab.id;
 
-  if (message === TabMessage.Classify) {
+  if (message === TabMessage.Classify && sender.tab.active) {
     chrome.tabs
       .captureVisibleTab(sender.tab.windowId, { format: "jpeg" })
       .then((image) => {


### PR DESCRIPTION
This checks that the streaming platform tab is active before capturing, and aborts the prediction flow if the tab isn't active. This avoids capturing irrelevant tabs and updating based on that. Kind of a bandaid still, since it also pauses updates while the platform tab is inactive.

https://nbolam.atlassian.net/browse/SIL-53